### PR TITLE
Fix: configured board name lost on external-edit reload

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -318,6 +318,8 @@ export function createTuiStore({ config }: CreateStoreOptions) {
       // change — and spuriously flash "Reloaded after external edit". Skip.
       if (lastWrittenContent.get(filepath) === content) return;
       const { board } = parseBoard(content, { filepath });
+      const boardConfig = config.boards.find((cb) => cb.path === filepath);
+      if (boardConfig?.name) board.name = boardConfig.name;
       const mtimeMs = statMtime(filepath);
       setState(
         "boards",


### PR DESCRIPTION
## Summary

Fixes #10

- `loadAll()` applies each board's `config.boards[].name` override on
  startup, but the file-watcher's `onChange` reload handler re-parses the
  board from disk on external edits without reapplying that override, so
  the display name silently reverts to the filename-derived default the
  next time the file changes outside the app.
- This reapplies the configured name (matched by filepath) in the reload
  path too, mirroring what `loadAll()` already does on initial load.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` — all 98 existing tests pass
- [x] Manually verified: registered a board with a custom `name`, launched
      tuiboard, edited the underlying file externally, confirmed the
      display name now survives the reload instead of reverting to the
      filename.

[Generated using claude]